### PR TITLE
fix a typo on the url

### DIFF
--- a/conf/ini-files/Zea_mays.ini
+++ b/conf/ini-files/Zea_mays.ini
@@ -29,9 +29,6 @@ MAIZEGDB_GENE = http://www.maizegdb.org/cgi-bin/displaygenemodelrecord.cgi?id=##
 
 [ENSEMBL_SPECIES_SITE]
 
-[ENSEMBL_INTERNAL_DAS_SOURCES]
-
-
 [SPECIES_DISPLAY_NAME]
 
 [SPECIES_DISPLAY_NAME]
@@ -49,3 +46,107 @@ MAIZEGDB_GENE = http://www.maizegdb.org/cgi-bin/displaygenemodelrecord.cgi?id=##
 [S4_PROTEIN_STRUCTURE]
 
 [S4_LITERATURE]
+
+[ENSEMBL_INTERNAL_BAM_SOURCES]
+
+[B73_1_RNAseq]
+source_name = RNAseq
+description = testing RNAseq BAM
+source_url = http://brie.cshl.edu/data/Zea_mays/RNAseq/B73_1_sequence.accepted_hits.bam
+source_type = bam
+display = wiggle
+
+[ENSEMBL_INTERNAL_BIGBED_SOURCES]
+HClncRNAs = mrna_prot
+
+[HClncRNAs]
+source_name = HC_lncRNAs
+description = High Confidence lncRNAs
+source_url = http:/brie.cshl.edu/data/Zea_mays/HC-lncRNAs.bb
+source_type = bigbed
+
+[ENSEMBL_INTERNAL_BIGWIG_SOURCES]
+B73_CpG_ratio = functional
+B73_CpG_coverage = functional
+B73_CHG_ratio = functional
+B73_CHG_coverage = functional
+MO17_CpG_ratio = functional
+MO17_CpG_coverage = functional
+MO17_CHG_ratio = functional
+MO17_CHG_coverage = functional
+
+[B73_CpG_ratio]
+source_name = B73_CpG_ratio
+description = B73 CpG methylation ratio from bisulfite sequencing
+source_url = http://brie.cshl.edu/data/Zea_mays/methylome/B73_CpG_ratio.bw
+source_type = bigwig
+display = wiggle
+
+[B73_CpG_coverage]
+source_name = B73_CpG_coverage
+description = B73 CpG methylation coverage from bisulfite sequencing
+source_url = http://brie.cshl.edu/data/Zea_mays/methylome/B73_CpG_coverage.bw
+source_type = bigwig
+display = wiggle
+
+[B73_CHG_ratio]
+source_name = B73_CHG_ratio
+description = B73 CHG methylation ratio from bisulfite sequencing
+source_url = http://brie.cshl.edu/data/Zea_mays/methylome/B73_CHG_ratio.bw
+source_type = bigwig
+display = wiggle
+
+[B73_CHG_coverage]
+source_name = B73_CHG_coverage
+description = B73 CHG methylation coverage from bisulfite sequencing
+source_url = http://brie.cshl.edu/data/Zea_mays/methylome/B73_CHG_coverage.bw
+source_type = bigwig
+display = wiggle
+
+[MO17_CpG_ratio]
+source_name = MO17_CpG_ratio
+description = MO17 CpG methylation ratio from bisulfite sequencing
+source_url = http://brie.cshl.edu/data/Zea_mays/methylome/MO17_CpG_ratio.bw
+source_type = bigwig
+display = wiggle
+
+[MO17_CpG_coverage]
+source_name = MO17_CpG_coverage
+description = MO17 CpG methylation coverage from bisulfite sequencing
+source_url = http://brie.cshl.edu/data/Zea_mays/methylome/MO17_CpG_coverage.bw
+source_type = bigwig
+display = wiggle
+
+[MO17_CHG_ratio]
+source_name = MO17_CHG_ratio
+description = MO17 CHG methylation ratio from bisulfite sequencing
+source_url = http://brie.cshl.edu/data/Zea_mays/methylome/MO17_CHG_ratio.bw
+source_type = bigwig
+display = wiggle
+
+[MO17_CHG_coverage]
+source_name = MO17_CHG_coverage
+description = MO17 CHG methylation coverage from bisulfite sequencing
+source_url = http://brie.cshl.edu/data/Zea_mays/methylome/MO17_CHG_coverage.bw
+source_type = bigwig
+display = wiggle
+
+[ENSEMBL_INTERNAL_DAS_SOURCES]
+MAKERP = gene_transcript
+
+[MAKERP]
+dsn     = 6a
+label   = MAKER-P
+caption = MAKER-P genes
+description = Gene annotations contributed by developers of the MAKER-P annotation system
+url     = http://brie:9509/das
+authority = http://www.gramene.org
+homepage  = http://www.gramene.org
+on        = [ contigview ]
+type      = ensembl_location
+coords    = toplevel
+labelflag = U
+stylesheet = y
+group     = 0
+depth = 9999
+strand = b


### PR DESCRIPTION
there is a missing / on one of the bigBed file url. 
http:/brie.cshl.edu/data/Zea_mays/HC-lncRNAs.bb
changed to
http://brie.cshl.edu/data/Zea_mays/HC-lncRNAs.bb