### PR TITLE
fix the path for the arabidopsis VCF file

### DIFF
--- a/conf/json/arabidopsis_thaliana_vcf.json
+++ b/conf/json/arabidopsis_thaliana_vcf.json
@@ -7,7 +7,7 @@
             "species": "arabidopsis_thaliana",
             "assembly": "TAIR10",
             "type": "remote",
-            "filename_template": "http://ftp.ebi.ac.uk/pub/databases/eva/PRJNA273563/submitted_files/1001genomes_snp-short-indel_only_ACGTN_v3.1.snpeff.garys.final.vcf.gz",
+            "filename_template": "http://ftp.sra.ebi.ac.uk/vol1/ERZ345/ERZ345220/1001genomes_snp-short-indel_only_ACGTN_v3.1.snpeff.garys.final.vcf.gz",
             "chromosomes": [
                 "1", "2", "3", "4", "5"
             ],


### PR DESCRIPTION
Hi @nicklangridge, here is the patch we discussed. The new file exists at that location, along with a similarly named TBI file.