### PR TITLE
Fix config for Triticum aestivum

### DIFF
--- a/conf/json/triticum_aestivum_vcf.json
+++ b/conf/json/triticum_aestivum_vcf.json
@@ -6,7 +6,7 @@
         "id": "820K",
         "species": "triticum_aestivum",
         "assembly": "IWGSC",
-        "type": "remote",
+        "type": "local",
         "filename_template": "/triticum_aestivum/IWGSC/variation_genotype/triticum_aestivum/820k.vcf.gz",
         "chromosomes": [
             "1A","1B","1D", "2A","2B","2D","3A","3B","3D","4A","4B","4D","5A","5B","5D","6A","6B","6D","7A","7B","7D","Un"
@@ -19,7 +19,7 @@
         "id": "35K",
         "species": "triticum_aestivum",
         "assembly": "IWGSC",
-        "type": "remote",
+        "type": "local",
         "filename_template": "/triticum_aestivum/IWGSC/variation_genotype/triticum_aestivum/35k.vcf.gz",
         "chromosomes": [
             "1A","1B","1D", "2A","2B","2D","3A","3B","3D","4A","4B","4D","5A","5B","5D","6A","6B","6D","7A","7B","7D","Un"


### PR DESCRIPTION
Similar to https://github.com/EnsemblGenomes/eg-web-plants/pull/29, but this time fixing the config for Triticum aestivum (bug introduced in https://github.com/EnsemblGenomes/eg-web-plants/pull/28).