### PR TITLE
added NCBI URL instead of ENA

### DIFF
--- a/conf/ini-files/beta_vulgaris.ini
+++ b/conf/ini-files/beta_vulgaris.ini
@@ -9,6 +9,8 @@ SPECIES_RELEASE_VERSION = 2
 EGB_PHY = bvseq
 
 [ENSEMBL_EXTERNAL_URLS]
+PROTEIN_ID = https://www.ncbi.nlm.nih.gov/protein/###ID###
+PROTEIN_ID_predicted = https://www.ncbi.nlm.nih.gov/protein/###ID###
 
 [ENSEMBL_SPECIES_SITE]
 


### PR DESCRIPTION
HI @ens-ap5 @gnaamati , following @james-monkeyshines reporting https://www.ebi.ac.uk/panda/jira/browse/ENSINT-492 , this edit attempts to solve the problem for beta_vulgaris .
It might well be that we have to do similarly for other species.
Let me know if the syntax is not correct, thanks,
Bruno