### PR TITLE
updated annotation of repeats docs and strain blurbs for release 52/105

### DIFF
--- a/htdocs/Brassica_rapa_strains.inc
+++ b/htdocs/Brassica_rapa_strains.inc
@@ -1,0 +1,17 @@
+<div class="column-wrapper">
+  <div class="column-two">
+    <div class="column-left">
+
+<p>The genome assembly of cultivar Chiifu-401-42 was published on
+<a href="https://europepmc.org/abstract/MED/21873998">August 2011</a>
+and includes 193 scaffolds orientated and assigned to pseudochromosomes using publicly
+available genetic markers.</p>
+
+<p> Gene annotation was conducted using GLEAN and BLAT, with functional annotation inferred 
+through similarity to *Arabidopsis thaliana* genes. Repeats were annotated with the 
+<a href="http://plants.ensembl.org/info/genome/annotation/repeat_features.html">Ensembl Genomes repeat feature pipeline</a>.
+There are: 655,980 Low complexity (Dust) features, covering 33 Mb (11.8% of the genome); 209,256 RepeatMasker features (with the nrplants library), covering 88 Mb (31.1% of the genome); 118,356 RepeatMasker features (with the RepBase library), covering 32 Mb (11.4% of the genome); 145,117 Tandem repeats (TRF) features, covering 14 Mb (4.8% of the genome).</p>
+
+    </div>
+  </div>
+</div>

--- a/htdocs/Olea_europaea_strains.inc
+++ b/htdocs/Olea_europaea_strains.inc
@@ -1,0 +1,35 @@
+<div class="column-wrapper">
+  <div class="column-two">
+    <div class="column-left">
+
+<p>*Olea europaea* var. *sylvestris* (wild olive, oleaster, acebuche) is a
+small evergreen tree native to the Mediterranean basin which is
+considered an ancestor of cultivated olive trees. 
+DNA was extracted from leaves collected from trees in the Orhangazi
+region of Bursa city (Turkey). The genome was shotgun-sequenced (220x
+coverage) and SOAPdenovo used to assemble the reads, 
+which resulted in a draft genome assembly of 1.48 Gbp, 
+which is in agreement with genome size estimations from flow
+cytometry and k-mer analysis. By using genetic maps with 1,307 markers, 
+50% of sequences longer than 1 kbp (∼572 Mbp) could be anchored into 23 linkage groups.</p>
+
+<p> Homology-based and de novo methods, as well as RNA-seq data, were used
+to predict genes. GLEAN was used to consolidate results. Protein 
+sequences of several plants were aligned with TBLASTN and genBLASTA
+against the matching genomic sequence by using GeneWise for accurate
+spliced alignments. Next, the de novo gene-prediction methods GlimmerHMM
+and Augustus were used to predict protein-coding genes, with parameters
+trained for <i>O. europaea var. sylvestris</i>, <i>Arabidopsis thaliana</i>, 
+<i>Sesamum indicum</i>, <i>Solanum tuberosum</i> and <i>Vitis vinifera</i>.
+Repeats were annotated with the 
+<a href="http://plants.ensembl.org/info/genome/annotation/repeat_features.html">Ensembl Genomes repeat feature pipeline</a>.
+There are: 1619023 Low complexity (Dust) features, covering 160 Mb (14.0% of
+the genome); 1281455 RepeatMasker features (with the REdat library),
+covering 261 Mb (22.9% of the genome); 8004 RepeatMasker features (with
+the RepBase library), covering 1 Mb (0.1% of the genome); 513948 Tandem
+repeats (TRF) features, covering 374 Mb (32.8% of the genome); 
+Repeated sequences called with the Repeat Detector cover 45.2% of the genome.</p>
+
+    </div>
+  </div>
+</div>

--- a/htdocs/info/about/collaborations/gramene.html
+++ b/htdocs/info/about/collaborations/gramene.html
@@ -9,7 +9,7 @@
 <p>
 <a href="http://www.gramene.org">
 <img src="/img/gramene_logo.png" alt="Gramene logo" style="width:200px;height:79px" class="float-left"></a>
-Ensembl Plants is a joint project of the <a href="https://www.ebi.ac.uk/">European Bioinformatics Institute</a> and the group of <a href="http://www.cshl.edu/public/SCIENCE/ware.html">Doreen Ware</a> 
+Ensembl Plants is a joint project of the <a href="https://www.ebi.ac.uk/">European Bioinformatics Institute</a> and the group of <a href="https://www.cshl.edu/research/faculty-staff/doreen-ware">Doreen Ware</a> 
 at the <a href="http://www.cshl.org/">Cold Spring Harbor Laboratory</a>, who have developed 
 the <a href="http://www.gramene.org/">Gramene</a> database [1,3,4,6], a resource for plant 
 comparative genomics based on Ensembl technology [2,5,7]. Databases are constructed in a direct 

--- a/htdocs/info/genome/annotation/repeat_features.html
+++ b/htdocs/info/genome/annotation/repeat_features.html
@@ -1,0 +1,54 @@
+<html>
+<head>
+<meta name="order" content="7" />
+<title>Repeat feature annotation</title>
+</head>
+
+<body>
+
+<h1>Repeat feature annotation</h1>
+
+<p>Several software programs are run to annotate three types of repeats:</p>
+
+<ul>
+  <li>Low-complexity regions (Dust [1])</li>
+  <li>Tandem repeats (<a href="http://tandem.bu.edu/trf/trf.html">TRF</a> [2])</li>
+  <li>Complex repeats: <ul>
+    <li> <a href="http://repeatmasker.org/">RepeatMasker</a> [3] </li>
+    <li> <a href="https://github.com/BioinformaticsToolsmith/Red">Repeat Detector (Red)</a> [4] and <a href="https://github.com/Ensembl/plant-scripts">Ensembl/plant-scripts</a> [5]</li>
+    </ul></li>
+</ul>
+
+<p>Annotating repeats with RepeatMasker requires a repeat library. 
+Repeat libraries from the following sources are used and combined where possible:</p>
+
+<ul>
+  <li>The <a href="https://pgsb.helmholtz-muenchen.de/plant/recat">MIPS Repeat Database (REdat)</a>.</li> 
+  
+  <li><a href="https://github.com/Ensembl/plant-scripts/releases/tag/v0.3">nrTEplants</a>, 
+  a curated library with repeated sequences annotated at REdat,   
+  <a href="http://urgi.versailles.inra.fr/repetdb/begin.do">RepetDB</a>, 
+  <a href="http://botserv2.uzh.ch/kelldata/trep-db">TREP</a> and other collections [5].</li>
+</ul>
+
+<h2>Viewing and accessing repeat features</h2>
+
+<p>By default, repeat features are not displayed in the genome browser; display them by using 
+the <a href="/info/website/control_panel.html">Configure this page</a> option. You can view all 
+repeats, or a subset of repeats based on type.</p>
+
+<p>The repeat annotations can be programatically accessed using the 
+<a href="/info/data/api.html">Ensembl API</a>. See the <a href="http://www.ensembl.org/info/docs/Doxygen/core-api/classBio_1_1EnsEMBL_1_1RepeatFeature.html">RepeatFeature</a> and <a href="http://www.ensembl.org/info/docs/Doxygen/core-api/classBio_1_1EnsEMBL_1_1DBSQL_1_1RepeatFeatureAdaptor.html">RepeatFeatureAdaptor</a> documentation for further details.</p>
+
+<h2>References</h2>
+
+<ol>
+  <li>Morgulis A <em>et al.</em> (2006) <a href="http://europepmc.org/abstract/MED/16796549">A fast and symmetric DUST implementation to mask low-complexity DNA sequences.</a> J Comput Biol. <b>13</b>:1028-40</li>
+  <li>Benson G (1999) <a href="http://europepmc.org/abstract/MED/9862982">Tandem repeats finder: a program to analyze DNA sequences.</a> Nucleic Acids Res. <b>27</b>: 573-580</li>
+  <li>Smit AFA, Hubler R, Green P (2015) <em>RepeatMasker Open-4.0</em> <a href="http://www.repeatmasker.org">http://www.repeatmasker.org</a></li>
+  <li>Girgis HZ (2015) <a href="https://europepmc.org/article/MED/26206263">Red: an intelligent, rapid, accurate tool for detecting repeats de-novo on the genomic scale.</a> BMC Bioinformatics, <b>16</b>:227</li>
+  <li>Contreras-Moreira B, Filippi CV, Naamati G, Garcí&iacute;a Gir&oacute;n C, Allen JE, Flicek P (2021) <a href="https://europepmc.org/article/PPR/PPR302441">Efficient masking of plant genomes by combining kmer counting and curated repeats</a> Preprint from bioRxiv, DOI: 10.1101/2021.03.22.436504
+</ol>
+
+</body>
+</html>


### PR DESCRIPTION
HI @ens-ap5 @ens-ds23 @gnaamati ,
this PR adds 

1. plant-specific documentation for the annotation of repeats that matches the contents of release 52/105. I am hoping this will show up as http://plants.ensembl.org/info/genome/annotation/repeat_features.html
2. blurbs for strain summaries

Please let me know if you see anything wrong,
Bruno