### PR TITLE
Add docs for Cactus alignment method

### DIFF
--- a/htdocs/info/genome/compara/multiple_genome_alignments.html
+++ b/htdocs/info/genome/compara/multiple_genome_alignments.html
@@ -54,5 +54,9 @@ Further details on all these methods can be found at: <a href="http://europepmc.
 
 <p>By construction, each pair of EPO and EPO-Extended alignments represent the exact same alignment of chromosome-level genomes.</p>
 
+<h3 id="progressivecactus">Progressive Cactus</h3>
+
+<p>Progressive-Cactus is a next-generation aligner that stores whole-genome alignments in a graph structure. Genomes can be added incrementally, which makes it scalable to hundreds of genomes. Further details on these methods can be found in <a href="https://europepmc.org/articles/PMC3166836">Algorithms for genome multiple sequence alignment</a> and <a href="https://europepmc.org/abstract/MED/21385048">Cactus graphs for genome comparisons</a>.</p>
+
 </body>
 </html>


### PR DESCRIPTION
This adds documentation on the Cactus alignment method to the Ensembl Plants webpage showing the list of multiple genome alignments ([here](http://plants.ensembl.org/info/genome/compara/multiple_genome_alignments.html)).

(Cactus alignments were introduced to the Ensembl Plants in e110.)