### PR TITLE
Set release version of species updated in eg59

### DIFF
--- a/conf/ini-files/manihot_esculenta.ini
+++ b/conf/ini-files/manihot_esculenta.ini
@@ -1,5 +1,5 @@
 [general]
-SPECIES_RELEASE_VERSION = 1
+SPECIES_RELEASE_VERSION = 2
 
 [databases]
 

--- a/conf/ini-files/medicago_truncatula.ini
+++ b/conf/ini-files/medicago_truncatula.ini
@@ -1,5 +1,5 @@
 [general]
-SPECIES_RELEASE_VERSION = 2
+SPECIES_RELEASE_VERSION = 3
 
 [databases]
 


### PR DESCRIPTION
This configures Ensembl Plants eg59/e112 with the updated versions of Manihot esculenta and Medicago truncatula.

Manihot esculenta example links:
- `Manihot_esculenta_v6` on Ensembl Plants staging: https://staging-plants.ensembl.org/Manihot_esculenta/Info/Index
- `MtrunA17r5.0_ANR` on Ensembl Plants sandbox: http://wp-np2-25.ebi.ac.uk:5098/Manihot_esculenta/Info/Index

Medicago truncatula example links:
- `MedtrA17_4.0` on Ensembl Plants staging: https://staging-plants.ensembl.org/Medicago_truncatula/Info/Index
- `M.esculenta_v8` on Ensembl Plants sandbox: http://wp-np2-25.ebi.ac.uk:5098/Medicago_truncatula/Info/Index