### PR TITLE
Hide placeholder tree for Wheat Cactus alignment

### DIFF
--- a/modules/EnsEMBL/Web/Component/Compara_Alignments.pm
+++ b/modules/EnsEMBL/Web/Component/Compara_Alignments.pm
@@ -1,0 +1,15 @@
+package EnsEMBL::Web::Component::Compara_Alignments;
+
+use strict;
+use previous qw (draw_tree);
+### This is a fix for ENSWEB-6844 until we have a longer term fix.
+sub draw_tree {
+  my $self = shift;
+  my ($cdb, $align_blocks, $slice, $align, $class, $groups, $slices) = @_;
+  if ($align == 313160) {
+    return;
+  }
+  $self->PREV::draw_tree(@_);
+}
+
+1;


### PR DESCRIPTION
This PR would continue to hide the placeholder tree mediating access to the 16 Wheat Cactus alignment. (See [ENSWEB-6844](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6844)).

Example alignment region on sandbox: http://wp-np2-25.ebi.ac.uk:5098/Triticum_aestivum/Location/Compara_Alignments?align=313160;db=core;r=3D:2634350-2634543