### PR TITLE
Add vicia_faba to SiteDefs::PRODUCTION_NAMES

### DIFF
--- a/conf/SiteDefs.pm
+++ b/conf/SiteDefs.pm
@@ -187,6 +187,7 @@ sub update_conf {
       triticum_spelta
       triticum_turgidum 
       triticum_urartu
+      vicia_faba
       vigna_angularis
       vigna_radiata
       vigna_unguiculata


### PR DESCRIPTION
Adding `vicia_faba` to the `SiteDefs::PRODUCTION_NAMES` config variable would enable newly introduced species Vicia faba to be accessed on the Ensembl Plants 112 staging site.

Related links:

- Vicia faba page on Ensembl Plants 112 staging site: https://staging-plants.ensembl.org/Vicia_faba/Info/Index
- Vicia faba page on a Plants sandbox: http://wp-np2-25.ebi.ac.uk:5098/Vicia_faba/Info/Index
