### PR TITLE
Add aegilops_umbellulata to SiteDefs::PRODUCTION_NAMES

### DIFF
--- a/conf/SiteDefs.pm
+++ b/conf/SiteDefs.pm
@@ -49,6 +49,7 @@ sub update_conf {
       arabis_alpina
       asparagus_officinalis
       aegilops_tauschii
+      aegilops_umbellulata
       amborella_trichopoda
       avena_sativa_ot3098
       avena_sativa_sang


### PR DESCRIPTION
Adding `aegilops_umbellulata` to the `SiteDefs::PRODUCTION_NAMES` config variable would enable newly introduced species _Aegilops umbellulata_ to be accessed on the Ensembl Plants 112 RC site.

Related links:

- Aegilops umbellulata page on Ensembl Plants 112 RC site: https://rc-plants.ensembl.org/Aegilops_umbellulata/Info/Index
- Aegilops umbellulata page on a Plants sandbox: http://wp-np2-25.ebi.ac.uk:5098/Aegilops_umbellulata/Info/Index