### PR TITLE
Hide Wheat Cactus alignments

### DIFF
--- a/modules/EnsEMBL/Web/ConfigPacker.pm
+++ b/modules/EnsEMBL/Web/ConfigPacker.pm
@@ -1,0 +1,30 @@
+=head1 LICENSE
+
+Copyright [2009-2024] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License,  Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,  software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,  either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package EnsEMBL::Web::ConfigPacker;
+use strict;
+use warnings;
+
+
+sub _alignment_mlss_is_suppressed {
+    my ($self, $mlss_id) = @_;
+    # Suppress Wheat Cactus multiple and pairwise alignment MLSSes.
+    return $mlss_id >= 313160 && $mlss_id <= 313280 ? 1 : 0;
+}
+
+1;


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be efficiently reviewed may be rejected.
- Please consider which branch this is to be submitted against. This is usually obvious, however if it is to be applied to both a release branch nn and master then please submit it against postreleasefix/nn and let us merge it into to the two branches.

## Description

In conjunction with [ensembl-webcode PR 1017](https://github.com/Ensembl/ensembl-webcode/pull/1017), this PR (for the `release/eg/59` branch only) makes it possible to suppress the Wheat Cactus alignment on the Ensembl Plants 112 site.

To take effect, it is necessary to repack the `MULTI` packed file.

## Views affected

This change has the effect of making the Wheat Cactus alignment disappear from the Wheat genomic alignment dropdown, as well as from the multiple genomic alignment list.

Examples:
- [sandbox](http://wp-np2-25.ebi.ac.uk:5098/Triticum_aestivum/Location/View?r=3D:2585940-2634711)
- [live site](https://plants.ensembl.org/Triticum_aestivum/Location/View?r=3D:2585940-2634711)

## Possible complications

No complications are expected. The range of  suppressed MLSSes is restricted to those of the Wheat Cactus multiple and pairwise alignment MLSSes.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- [ENSWEB-6910](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6910)