### PR TITLE
Hide placeholder tree for Wheat CACTUS_DB alignment

### DIFF
--- a/modules/EnsEMBL/Web/Component/Compara_Alignments.pm
+++ b/modules/EnsEMBL/Web/Component/Compara_Alignments.pm
@@ -6,7 +6,7 @@ use previous qw (draw_tree);
 sub draw_tree {
   my $self = shift;
   my ($cdb, $align_blocks, $slice, $align, $class, $groups, $slices) = @_;
-  if ($align == 313160) {
+  if ($align == 314995) {
     return;
   }
   $self->PREV::draw_tree(@_);


### PR DESCRIPTION
This PR would continue to hide the placeholder tree mediating access to the 16 Wheat Cactus (now `CACTUS_DB`) alignment. (See [ENSWEB-6844](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6844)).

Example alignment region on sandbox: http://wp-np2-25.ebi.ac.uk:5098/Triticum_aestivum/Location/Compara_Alignments?align=314995;db=core;r=3D:2634350-2634543