### PR TITLE
Hide alt gene tracks in Wheat Cactus image align view

### DIFF
--- a/modules/EnsEMBL/Web/ImageConfig/alignsliceviewbottom.pm
+++ b/modules/EnsEMBL/Web/ImageConfig/alignsliceviewbottom.pm
@@ -1,0 +1,44 @@
+=head1 LICENSE
+
+Copyright [2009-2024] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package EnsEMBL::Web::ImageConfig::alignsliceviewbottom;
+
+use strict;
+
+
+sub _modify_cactus_db_transcript_tracks {
+  my $self = shift;
+
+  my $align_params = $self->hub->referer->{'params'}{'align'}[0];
+  my ($align) = split '--', $align_params;
+
+  if ($align == 314995) {
+    my $align_type = $self->species_defs->multi_hash->{'DATABASE_COMPARA'}{'ALIGNMENTS'}{$align}{'type'};
+    if ($align_type eq 'CACTUS_DB') {
+      my $node = $self->get_node('transcript');
+      my @tracks = grep { $_->get_data('node_type') eq 'track' } @{$node->get_all_nodes};
+      foreach my $track (@tracks) {
+        if ($track->get_data('key') ne 'ensembl') {
+          $track->set_data('display', 'off');
+        }
+      }
+    }
+  }
+}
+
+1;

--- a/modules/EnsEMBL/Web/ImageConfig/alignsliceviewbottom.pm
+++ b/modules/EnsEMBL/Web/ImageConfig/alignsliceviewbottom.pm
@@ -20,9 +20,14 @@ package EnsEMBL::Web::ImageConfig::alignsliceviewbottom;
 
 use strict;
 
+use previous qw (init_cacheable);
 
-sub _modify_cactus_db_transcript_tracks {
+
+sub init_cacheable {
+
   my $self = shift;
+
+  $self->PREV::init_cacheable(@_);
 
   my $align_params = $self->hub->referer->{'params'}{'align'}[0];
   my ($align) = split '--', $align_params;


### PR DESCRIPTION
## Description

Wheat Cactus alignments are taking time to load on the Ensembl Plants website.

This PR aims to reduce the loading time of the Wheat Cactus alignment by switching off alternative gene model tracks by default.

## Views affected

This PR affects the Wheat Cactus image alignment in the Ensembl Plants website, switching off alternative gene model tracks by default, and noticeably reducing the load time.

Example: [sandbox](http://wp-np2-25.ebi.ac.uk:5098/Triticum_aestivum_landmark/Location/Compara_Alignments/Image?r=6B:570561430-570611430;db=core;align=314995) vs [RC site](https://rc-plants.ensembl.org/Triticum_aestivum_landmark/Location/Compara_Alignments/Image?r=6B:570561430-570611430;db=core;align=314995)

## Possible complications

Because the changes in this PR are restricted to the Wheat `CACTUS_DB` image alignment on the Ensembl Plants website, that is the only view expected to be significantly affected.

## Merge conflicts

- None detected.

## Related JIRA Issues (EBI developers only)

- [ENSCOMPARASW-7793](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-7793)
