### PR TITLE
Update release version of vitis_vinifera for eg61

### DIFF
--- a/conf/ini-files/vitis_vinifera.ini
+++ b/conf/ini-files/vitis_vinifera.ini
@@ -1,5 +1,5 @@
 [general]
-SPECIES_RELEASE_VERSION = 4
+SPECIES_RELEASE_VERSION = 5
 
 [databases]
 


### PR DESCRIPTION
This configures Ensembl Plants eg61/e114 with the updated version of Vitis vinifera.

Vitis vinifera example links:
- Ensembl Plants staging: https://staging-plants.ensembl.org/Vitis_vinifera/Info/Index
- Ensembl Plants sandbox: http://wp-np2-25.ebi.ac.uk:5098/Vitis_vinifera/Info/Index
