### PR TITLE
Add ancestral sequences page to Plants web docs

### DIFF
--- a/htdocs/info/genome/compara/ancestral_sequences.html
+++ b/htdocs/info/genome/compara/ancestral_sequences.html
@@ -1,0 +1,17 @@
+<html>
+<head>
+
+  <meta name="navigation" content="Comparative Genomics">
+  <title>Ancestral sequences</title>
+
+
+</head>
+
+<body>
+
+<h1>Ancestral sequences</h1>
+
+<p><a href="https://europepmc.org/articles/PMC2577868">Ancestral sequences</a> are inferred from the <a href="/info/genome/compara/multiple_genome_alignments.html">EPO multiple alignments</a> using Ortheus. Ortheus is a probabilistic method for the inference of ancestor, a.k.a tree, alignments. The main contribution of Ortheus is the use of a phylogenetic model incorporating gaps to infer insertion and deletion events. Ancestral sequences are predicted for each node of the phylogenetic tree that relates the sequences. Each ancestral sequence is named according to the derived extant species. For example, a sequence named Hsap, Ptro, Mmul corresponds to the ancestor of the <i>Homo sapiens</i>, <i>Pan troglodytes</i>, and <i>Macaca mulatta</i> genomes.  </p>
+
+</body>
+</html>


### PR DESCRIPTION
This pull request would add an ancestral sequences page — much like [its counterpart in the Ensembl Vertebrates website](https://github.com/Ensembl/public-plugins/blob/7cfaaa40d33e8c5cb45371a8866a797f4131face/ensembl/htdocs/info/genome/compara/ancestral_sequences.html) — to the Ensembl Plants web docs.

This would effectively mend the broken link in the [Rice EPO text alignment](https://plants.ensembl.org/Oryza_sativa/Location/Compara_Alignments?r=5:20683551-20684336) offering information about [how ancestral sequences are calculated](https://plants.ensembl.org/info/genome/compara/ancestral_sequences.html):
![rice_ancestral_sequences_link](https://github.com/user-attachments/assets/2d4096b1-2082-40a0-9464-38dfd1608e48)