### PR TITLE
Set hordeum_vulgare_goldenmelon strain group in Plants ConfigPacker

### DIFF
--- a/modules/EnsEMBL/Web/ConfigPacker.pm
+++ b/modules/EnsEMBL/Web/ConfigPacker.pm
@@ -21,7 +21,19 @@ use strict;
 use warnings;
 no warnings qw(uninitialized);
 
-use previous qw(munge_databases_multi);
+use previous qw(_munge_meta munge_databases_multi);
+
+
+sub _munge_meta {
+  my $self = shift;
+  $self->PREV::_munge_meta(@_);
+  my $full_tree = $self->full_tree;
+  if (exists $full_tree->{'hordeum_vulgare_goldenmelon'}
+        && defined $full_tree->{'hordeum_vulgare_goldenmelon'}
+        && $full_tree->{'hordeum_vulgare_goldenmelon'}{'STRAIN_GROUP'} ne 'hordeum_vulgare') {
+    $self->tree('hordeum_vulgare_goldenmelon')->{'STRAIN_GROUP'} = 'hordeum_vulgare';
+  }
+}
 
 sub munge_databases_multi {
   my $self = shift;


### PR DESCRIPTION
## Description

This pull request would set the `STRAIN_GROUP` of `hordeum_vulgare_goldenmelon` in the Plants `ConfigPacker` module, ensuring consistent handling of this Barley cultivar in web views.

This PR has been submitted against the `release/eg/61` branch: this is a proposed solution for release e114/eg61 only, in the expectation that a more effective solution will be implemented for this Barley cultivar from release e115/eg62 onwards.

## Views affected

This change would affect the [Barley cultivar list view](https://rc-plants.ensembl.org/Hordeum_vulgare/Info/Cultivars?db=core) and any view relying on the `STRAIN_GROUP` metadata for correct handling of Barley cultivars.

Example Barley cultivar list view before change:
![barley_goldenmelon_strain_group_before](https://github.com/user-attachments/assets/a3a23a84-1557-4039-8fc4-5bfdc4b6e3aa)


Example Barley cultivar list view after change:
![barley_goldenmelon_strain_group_after](https://github.com/user-attachments/assets/6d3a8225-d921-4b15-b2f5-73122973e361)