### PR TITLE
Update Plants multiple genome alignment docs

### DIFF
--- a/htdocs/info/genome/compara/epo_anchors_info.html
+++ b/htdocs/info/genome/compara/epo_anchors_info.html
@@ -1,0 +1,50 @@
+<html>
+<head>
+  <meta name="navigation" content="Comparative Genomics">
+  <title>EPO Pipeline</title>
+</head>
+
+<body>
+
+<p>
+In the EPO pipeline; <a href="https://github.com/jherrero/enredo">Enredo</a>, <a href="https://github.com/benedictpaten/pecan">Pecan</a> and <a href="https://github.com/benedictpaten/ortheus">Ortheus</a> are just the tip of the iceberg.
+These combined methods use information from homology and synteny, that is derived from <em>anchor</em> sequence alignments.
+This page provides a summary of what the anchors are, how they are generated, and how they are used.
+</p>
+
+<h3 id="anchorgeneration">Anchor generation</h3>
+
+<p>
+The anchors represent short regions of conservation, typically about 100 bases in length, from a phylogenetically representative subset of the species we wish to align.
+As such, anchors only have to be regenerated when the subset of species used is not representative any more.
+</p>
+
+<p>
+The anchor set is generated from pairwise alignments (LastZ-Net) of a non-reference species to a selected reference species. All the species chosen to generate the anchors must have a pairwise alignment with the selected reference species.
+The pairwise alignments are stacked together based on their coordinates and the regions are realigned with Pecan.
+Then <a href="https://europepmc.org/article/pmc/2996323">GERP</a> is used to identify conserved regions, from where the anchor sequences are defined.
+</p>
+
+<p>
+We consider a good anchor set to contain hundreds of thousands of anchors in order to cover the genomes optimally.
+</p>
+
+<h3 id="anchormapping">Anchor mapping</h3>
+<p>
+The anchor set is mapped (currently we use <a href="https://europepmc.org/article/MED/15713233">exonerate</a>) against all the genomes we wish to include in the final alignment.
+Overlapping anchors are filtered so that any particular genomic location is associated with, at most, one anchor.
+</p>
+
+<p>
+This step is computationally expensive, however, running independently per genome, it can be modelled as a cumulative process.
+Assuming the anchors have not changed, we only need to run it for the new assemblies, and can reuse mappings from existing assemblies.
+</p>
+
+<h3 id="genomealignment">Genome alignment</h3>
+
+<p>
+Enredo extracts a list of homologous genomic regions from the positions where the anchors have mapped. These homologous regions are then aligned with Pecan or Ortheus. Ortheus uses Pecan to align the sequences and additionally generates a consensus sequence for each ancestral node in a tree. This ancestral sequence is predicted for each aligned region.
+</p>
+
+</body>
+</html>

--- a/htdocs/info/genome/compara/multiple_genome_alignments.html
+++ b/htdocs/info/genome/compara/multiple_genome_alignments.html
@@ -22,13 +22,13 @@
 
 <h3 id="pecanmultiplealignment">PECAN Multiple Alignment</h3>
 
-<p><a href="https://github.com/benedictpaten/pecan">Pecan</a> is used to provide global multiple genomic alignments. First, Mercator is used to build a synteny map between the genomes and then Pecan builds alignments in these syntenic regions.</p>
+<p>Pecan <a href="#fn1">[1]</a> is used to provide global multiple genomic alignments. First, Mercator is used to build a synteny map between the genomes and then Pecan builds alignments in these syntenic regions.</p>
 
-<p>Pecan is a global multiple sequence alignment program that makes practical the probabilistic consistency methodology for significant numbers of sequences of practically arbitrary length. As input it takes a set of sequences and a phylogenetic tree. The parameters and heuristics it employs are highly user configurable, it is written entirely in Java and also requires the installation of Exonerate.</p>
+<p>Pecan is a global multiple sequence alignment program that makes practical the probabilistic consistency methodology for significant numbers of sequences of practically arbitrary length. As input it takes a set of sequences and a phylogenetic tree. The parameters and heuristics it employs are highly user configurable, it is written entirely in Java and also requires the installation of exonerate <a href="#fn2">[2]</a>.</p>
 
 <h3 id="epomultiplealignment">EPO Multiple Alignment</h3>
 
-<p>The EPO (Enredo, Pecan, Ortheus) pipeline is a three step pipeline for whole-genome multiple alignments.</p>
+<p>The EPO (Enredo, Pecan, Ortheus) <a href="#fn1">[1]</a> pipeline is a three step pipeline for whole-genome multiple alignments.</p>
 
 <ol>
 <li>Enredo produces colinear segments from extant genomes handling both rearrangements, deletions and duplications.</li>
@@ -40,7 +40,6 @@
 
 <p>
 The pipeline requires alignments of so-called <em>anchor</em> sequences, which are explained <a href="/info/genome/compara/epo_anchors_info.html">here</a>.
-Further details on all these methods can be found at: <a href="https://europepmc.org/abstract/MED/18849524">Enredo and Pecan: Genome-wide mammalian consistency-based multiple alignment with paralogs</a>
 </p>
 
 <h4 id="epo2xmultiplealignment">EPO-Extended Multiple Alignment</h4>
@@ -56,7 +55,96 @@ Further details on all these methods can be found at: <a href="https://europepmc
 
 <h3 id="progressivecactus">Progressive Cactus</h3>
 
-<p>Progressive-Cactus is a next-generation aligner that stores whole-genome alignments in a graph structure. Genomes can be added incrementally, which makes it scalable to hundreds of genomes. Further details on these methods can be found in <a href="https://europepmc.org/articles/PMC3166836">Algorithms for genome multiple sequence alignment</a> and <a href="https://europepmc.org/abstract/MED/21385048">Cactus graphs for genome comparisons</a>.</p>
+<p>
+Progressive-Cactus <a href="#fn3">[3]</a> is a next-generation aligner that stores whole-genome
+alignments in a graph structure. Genomes can be added incrementally, which makes it scalable to
+hundreds of genomes.
+</p>
+
+<p>The Ensembl Compara Perl API provides access to Cactus alignment data in one of two ways: via HAL file (CACTUS_HAL) or database (CACTUS_DB).</p>
+
+<h4>Cactus alignment via HAL file</h4>
+
+<p>
+Alignments of type CACTUS_HAL are accessed via a HAL file <a href="#fn4">[4]</a>. For performance reasons,
+alignments are filtered to remove blocks whose length is below a threshold set to approximately one thousandth
+the size of the genomic region being accessed. Within each alignment block, aligned sequences are deduplicated
+per genome, keeping only the aligned sequence with the greatest number of nucleotides for the given genome.
+</p>
+
+<h4>Cactus alignment via database</h4>
+
+<p>
+Alignments of type CACTUS_DB are preloaded from a HAL file into a MySQL database following
+an approach similar to that used by cactus-hal2maf <a href="#fn3">[3]</a> (version 2.9.7).
+</p>
+
+<ol>
+  <li>
+  Dump a <a href="https://genome.ucsc.edu/FAQ/FAQformat.html#format5">MAF alignment</a> file for a given reference genome
+  (e.g. <i class="taxonomy">Triticum aestivum</i>) and sequence region (typically 500 kilobases in length) using hal2maf
+  <a href="#fn4">[4]</a> (version 2.2) with command-line options: <code>--noAncestors --unique</code>
+  </li>
+
+  <li>
+  Filter out aligned sequences with fewer than 5 nucleotides, and filter out alignment blocks with fewer than 20 alignment columns.
+  </li>
+
+  <li>
+  Normalise the alignment to merge smaller alignment blocks using <a href="https://github.com/ComparativeGenomicsToolkit/taffy">taffy</a>
+  (<a href="https://github.com/ComparativeGenomicsToolkit/taffy/commit/5221c50fbf119699db1112ce74eea90dea17ba95">commit 5221c50</a>)
+  with command-line options: <code>--filterGapCausingDupes --maximumBlockLengthToMerge 8000 --maximumGapLength 1200</code>
+  </li>
+
+  <li>
+  Deduplicate alignments per genome within each MAF block using the mafDuplicateFilter command of mafTools <a href="#fn5">[5]</a>
+  (<a href="https://github.com/ComparativeGenomicsToolkit/mafTools/commit/259e5b47fa2ee17ff5ad1bba9cebf2992cbb7228">commit 259e5b4 of ComparativeGenomicsToolkit version</a>) with command-line option: <code>--keep-first</code>
+  </li>
+
+  <li>
+  Load MAF alignment blocks into the output MySQL database.
+  </li>
+</ol>
+
+<p>
+CACTUS_DB alignments are also filtered by the Compara Perl API at access time,
+with the minimum block length set to one hundredth the size of the accessed region.
+</p>
+
+<h2 id="references">References</h2>
+
+<ol>
+  <li id="fn1">
+  Paten B, Herrero J, Beal K, Fitzgerald S, Birney E.
+  "<a href="https://github.com/jherrero/enredo">Enredo</a> and <a href="https://github.com/benedictpaten/pecan">Pecan</a>:
+  Genome-wide mammalian consistency-based multiple alignment with paralogs."
+  <a href="https://europepmc.org/abstract/MED/18849524">Genome Res. 2008 Nov;18(11):1814-28.</a>
+  </li>
+
+  <li id="fn2">
+  Slater GS, Birney E.
+  "Automated generation of heuristics for biological sequence comparison."
+  <a href="https://europepmc.org/article/MED/15713233">BMC Bioinformatics. 2005 Feb;6:31.</a>
+  </li>
+
+  <li id="fn3">
+  Armstrong J, Hickey G, Diekhans M, et al.
+  "Progressive Cactus is a multiple-genome aligner for the thousand-genome era."
+  <a href="https://europepmc.org/article/pmc/pmc7673649">Nature. 2020 Nov;587(7833):246-251.</a>
+  </li>
+
+  <li id="fn4">
+  Hickey G, Paten B, Earl D, Zerbino D, Haussler D.
+  "HAL: a hierarchical format for storing and analyzing multiple genome alignments."
+  <a href="https://europepmc.org/article/MED/23505295">Bioinformatics. 2013 May;29(10):1341-1342.</a>
+  </li>
+
+  <li id="fn5">
+  Earl D, Nguyen N, Hickey G, et al.
+  "Alignathon: a competitive assessment of whole-genome alignment methods."
+  <a href="https://europepmc.org/article/MED/25273068">Genome Research. 2014 Dec;24(12):2077-2089.</a>
+  </li>
+</ol>
 
 </body>
 </html>


### PR DESCRIPTION
In conjunction with [public-plugins PR 900](https://github.com/Ensembl/public-plugins/pull/900) and [eg-web-metazoa PR 50](https://github.com/EnsemblGenomes/eg-web-metazoa/pull/50), this PR would update the multiple genome alignment documentation, with a particular focus on Cactus alignments.

It would also add page `epo_anchors_info.html` to Ensembl Plants docs.

Example on Plants sandbox: http://wp-np2-35.ebi.ac.uk:5098/info/genome/compara/multiple_genome_alignments.html