### PR TITLE
Update text about between-species paralogies

### DIFF
--- a/htdocs/info/genome/compara/homology_method.html
+++ b/htdocs/info/genome/compara/homology_method.html
@@ -30,7 +30,7 @@ given internal node of the tree.
 
 
 <p>
-Please note that, primarily due to storage limitations, between-species paralogy relationships are not stored in the Compara databases or listed on the website (except in some special cases described in the "Between-species paralogues" section of the <a href="/info/genome/compara/homology_types.html">homology types documentation</a>). However, these relationships can be identified by examining the gene trees, which are annotated with duplication events.
+Please note that, primarily due to performance limitations, between-species paralogy relationships are not stored in the Compara databases or listed on the website (except in some special cases described in the "Between-species paralogues" section of the <a href="/info/genome/compara/homology_types.html">homology types documentation</a>). However, these relationships can be identified by examining the gene trees, which are annotated with duplication events.
 </p>
 
 


### PR DESCRIPTION
This PR would make a correction in a note of the storage of between-species paralogies, making it consistent with Vertebrates and general non-vertebrate documentation.