### PR TITLE
Add conservation docs for Ensembl Plants

### DIFF
--- a/htdocs/info/genome/compara/conservation_and_constrained.html
+++ b/htdocs/info/genome/compara/conservation_and_constrained.html
@@ -1,0 +1,40 @@
+<html>
+<head>
+
+  <meta name="navigation" content="Comparative Genomics">
+  <title>Conservation scores and constrained elements</title>
+
+</head>
+
+<body>
+
+<h1>Conservation scores and constrained elements</h1>
+
+<p>
+We use <a href="https://europepmc.org/article/pmc/2996323">GERP</a> to
+calculate conservation scores and call constrained elements on the rice EPO_EXTENDED
+<a href="/info/genome/compara/multiple_genome_alignments.html">multiple alignment</a>.
+Calculation of these scores for different species groups allows the determination of
+regions that are conserved in one taxon but not another.
+</p>
+
+<h2 id="conservationscores">Conservation scores</h2>
+
+<p>
+Conservation scores are calculated per base, indicating how many species in a given
+multiple alignment match at each locus.
+</p>
+
+<h2 id="constrainedelements">Constrained elements</h2>
+
+<p>
+Constrained elements are stretches of the multiple alignment where the sequences are highly
+conserved according to the previous score. This is calculated using GERP, which uses a
+permutation test to identify specific segments of the alignment that appear to be more
+conserved than expected by random chance. The p-values of constrained elements are calculated
+using a <a href="https://europepmc.org/article/MED/15965027">permutation test</a> to generate
+new alignments which define the distribution of random expectation.
+</p>
+
+</body>
+</html>


### PR DESCRIPTION
This PR adds documentation on conservation scores and constrained elements to Ensembl Plants.

As well as providing information relevant to data associated with the rice EPO_EXTENDED alignments, it supports [ensembl-webcode PR 1110](https://github.com/Ensembl/ensembl-webcode/pull/1110), ensuring that the link in the descriptions of conservation-score and constrained-element tracks on the Ensembl Plants site can point to Plants-specific documentation.