### PR TITLE
Enable prepacking of Compara intraspecies alignment summary

### DIFF
--- a/conf/prepack-intraspecies-alignments.pl
+++ b/conf/prepack-intraspecies-alignments.pl
@@ -1,0 +1,42 @@
+#! /usr/bin/env perl
+
+# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+# Copyright [2016-2026] EMBL-European Bioinformatics Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+use strict;
+use warnings;
+
+# Tool for prepacking intra-species alignment data to a JSON file.
+#
+# $ ./prepack-intraspecies-alignments.pl mysql://anonymous@mysql-eg-publicsql.ebi.ac.uk:4157/ensembl_compara_plants_63_116 ./json/compara_intra_species_alignments.json
+
+use JSON;
+
+use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
+use EnsEMBL::Web::Utils::Compara qw(_fetch_intraspecies_constraints _summarise_compara_alignments);
+use Bio::EnsEMBL::Utils::IO qw(spurt);
+
+
+my ($compara_url, $output_file) = @ARGV;
+
+if (!($compara_url && $output_file)) {
+  die("please specify a Compara database URL and output file\n");
+}
+
+my $compara_dba = Bio::EnsEMBL::Compara::DBSQL::DBAdaptor->go_figure_compara_dba($compara_url);
+my $dbh = $compara_dba->dbc->db_handle;
+my $constraint = EnsEMBL::Web::Utils::Compara::_fetch_intraspecies_constraints($dbh);
+my $alignment_summary = EnsEMBL::Web::Utils::Compara::_summarise_compara_alignment_data($dbh, 'DATABASE_COMPARA', $constraint);
+spurt($output_file, JSON->new->pretty->encode($alignment_summary->{'INTRA_SPECIES_ALIGNMENTS'}));

--- a/modules/EnsEMBL/Web/ConfigPacker.pm
+++ b/modules/EnsEMBL/Web/ConfigPacker.pm
@@ -19,14 +19,18 @@ limitations under the License.
 package EnsEMBL::Web::ConfigPacker;
 use strict;
 use warnings;
+
+use Bio::EnsEMBL::Utils::IO qw(slurp);
+
 no warnings qw(uninitialized);
 
-use previous qw(munge_databases_multi);
+use previous qw(_summarise_compara_alignments munge_databases_multi);
 
 sub munge_databases_multi {
   my $self = shift;
   $self->PREV::munge_databases_multi(@_);
   $self->_configure_per_component_alignments;
+  $self->_load_intra_species_alignments_from_json;
 }
 
 sub _configure_per_component_alignments {
@@ -49,6 +53,44 @@ sub _configure_per_component_alignments {
   }
 
   $dbh->disconnect;
+}
+
+sub _find_intra_species_alignments_json_file {
+  my $self = shift;
+
+  my $json_location;
+  foreach my $confdir (@SiteDefs::ENSEMBL_CONF_DIRS) {
+    my $possible_json_location = "$confdir/json/compara_intra_species_alignments.json";
+    if (-f $possible_json_location) {
+      $json_location = $possible_json_location;
+      last;
+    }
+  }
+
+  return $json_location;
+}
+
+sub _load_intra_species_alignments_from_json {
+  my $self = shift;
+
+  my $json_file_path = $self->_find_intra_species_alignments_json_file();
+  # Skip if INTRA_SPECIES_ALIGNMENTS JSON file does NOT exist.
+  return if !$json_file_path;
+
+  my $db_name = 'DATABASE_COMPARA';
+  my $dbh = $self->db_connect($db_name);
+  $self->db_tree->{$db_name}{'INTRA_SPECIES_ALIGNMENTS'} = from_json(slurp($json_file_path));
+  $dbh->disconnect;
+}
+
+sub _summarise_compara_alignments {
+  my $self = shift;
+
+  my $json_file_path = $self->_find_intra_species_alignments_json_file();
+  # Skip if INTRA_SPECIES_ALIGNMENTS JSON file exists.
+  return if $json_file_path;
+
+  $self->PREV::_summarise_compara_alignments(@_);
 }
 
 1;


### PR DESCRIPTION
## Description

This pull request would add script `prepack-intraspecies-alignments.pl` to enable pre-packing of Ensembl Plants intraspecies alignment data to a JSON file.

It would also add 3 methods to `ConfigPacker`:
- `_find_intra_species_alignments_json_file` : to find the intraspecies alignments JSON file in a designated location in the `conf/` directory;
- `_load_intra_species_alignments_from_json` : to load intraspecies alignments from a JSON file if that JSON file is present;
- `_summarise_compara_alignments` : to call the standard method for packing intraspecies alignment data if the intraspecies alignments JSON file is *not* present.

In this way, it would be possible to prepack intraspecies alignment data and load the prepacked data during generation of the Plants `MULTI.db.packed` file.

## See also

- [ensembl-webcode PR 1171](https://github.com/Ensembl/ensembl-webcode/pull/1171)
- [eg-web-common PR 133](https://github.com/EnsemblGenomes/eg-web-common/pull/133)
